### PR TITLE
Added window customizations for decorations and window style

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,7 @@ dependencies = [
  "memoffset 0.9.1",
  "metal",
  "objc",
+ "raw-window-handle",
  "winit",
 ]
 

--- a/cgraph/Cargo.toml
+++ b/cgraph/Cargo.toml
@@ -6,12 +6,15 @@ edition = "2024"
 [lib]
 path = "src/cgraph.rs"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc = "0.2"
+raw-window-handle = "0.5"
+cocoa = "0.24"
+metal = "0.25"
+core-graphics-types = "0.1"
+
 [dependencies]
 winit = "0.28.0"
-metal = "0.25"
-objc = "0.2"
-cocoa = "0.24"
-core-graphics-types = "0.1"
 glam = "0.10"
 memoffset = "0.9"
 image = "0.25"

--- a/cgraph/examples/circle.rs
+++ b/cgraph/examples/circle.rs
@@ -4,7 +4,7 @@ use cgraph::{
 };
 
 fn main() {
-    let mut win = Window::new("Circle", 800, 600);
+    let mut win = Window::new("Circle", 800, 600, None);
 
     win.add_object(create_circle(
         Size::new(1000.0, 1000.0),

--- a/cgraph/examples/improved_shadow.rs
+++ b/cgraph/examples/improved_shadow.rs
@@ -8,7 +8,7 @@ use cgraph::{
 use glam::Vec2;
 
 fn main() {
-    let mut win = Window::new("Improved Shadows", 1200, 800);
+    let mut win = Window::new("Improved Shadows", 1200, 800, None);
 
     let object1 = create_quad_with_shadow(
         Size::new(200.0, 150.0),

--- a/cgraph/examples/poly.rs
+++ b/cgraph/examples/poly.rs
@@ -4,7 +4,7 @@ use cgraph::{
 };
 
 fn main() {
-    let mut win = Window::new("Polygons", 800, 600);
+    let mut win = Window::new("Polygons", 800, 600, None);
 
     win.add_object(create_polygon(
         Size::new(1000.0, 1000.0),

--- a/cgraph/examples/quad.rs
+++ b/cgraph/examples/quad.rs
@@ -4,7 +4,7 @@ use cgraph::{
 };
 
 fn main() {
-    let mut win = Window::new("Quad", 800, 600);
+    let mut win = Window::new("Quad", 800, 600, None);
 
     win.add_object(create_quad(
         Size::new(1000.0, 1000.0),

--- a/cgraph/examples/shadow.rs
+++ b/cgraph/examples/shadow.rs
@@ -4,7 +4,7 @@ use cgraph::{
 };
 
 fn main() {
-    let mut win = Window::new("Quad", 800, 600);
+    let mut win = Window::new("Quad", 800, 600, None);
 
     let mut object = create_quad(
         Size::new(1000.0, 1000.0),

--- a/cgraph/examples/shadow_control.rs
+++ b/cgraph/examples/shadow_control.rs
@@ -5,7 +5,7 @@ use cgraph::{
 use glam::Vec2;
 
 fn main() {
-    let mut win = Window::new("Dynamic Shadow Control", 800, 600);
+    let mut win = Window::new("Dynamic Shadow Control", 800, 600, None);
 
     let mut object = create_quad(
         Size::new(200.0, 200.0),

--- a/cgraph/examples/texture.rs
+++ b/cgraph/examples/texture.rs
@@ -5,7 +5,7 @@ use cgraph::{
 };
 
 fn main() {
-    let mut win = Window::new("Texture", 800, 600);
+    let mut win = Window::new("Texture", 800, 600, None);
 
     let mut object = create_rounded_quad(
         Size::new(1000.0, 1000.0),

--- a/cgraph/examples/window2.rs
+++ b/cgraph/examples/window2.rs
@@ -1,10 +1,10 @@
 use cgraph::{
     self,
-    app::{CoreEvent, CoreEventReference, CoreWindowEvent, Window},
+    app::{CoreEvent, CoreEventReference, CoreWindowEvent, Window, WindowOptions},
 };
 
 fn main() {
-    let mut win = Window::new("Window", 800, 600, None);
+    let mut win = Window::new("Window", 800, 600, Some(WindowOptions::resizable()));
     win.on_event(CoreEventReference::WindowEvent, |_, event| {
         if let CoreEvent::WindowEvent(CoreWindowEvent::KeyboardInput(input)) = event {
             println!("Key pressed: {input:?}");

--- a/cgraph/examples/window2.rs
+++ b/cgraph/examples/window2.rs
@@ -4,7 +4,7 @@ use cgraph::{
 };
 
 fn main() {
-    let mut win = Window::new("Window", 800, 600, Some(WindowOptions::resizable()));
+    let mut win = Window::new("Window", 800, 600, Some(WindowOptions::no_titlebar()));
     win.on_event(CoreEventReference::WindowEvent, |_, event| {
         if let CoreEvent::WindowEvent(CoreWindowEvent::KeyboardInput(input)) = event {
             println!("Key pressed: {input:?}");

--- a/cgraph/src/app/window.rs
+++ b/cgraph/src/app/window.rs
@@ -197,9 +197,8 @@ fn apply_window_options(
     if options.transparent {
         builder = builder.with_transparent(true);
     }
-
     if options.fullscreen {
-        // Fullscreen logic can be added here
+        builder = builder.with_fullscreen(Some(winit::window::Fullscreen::Borderless(None)));
     }
     builder
 }

--- a/cgraph/src/app/window.rs
+++ b/cgraph/src/app/window.rs
@@ -210,10 +210,7 @@ impl Window {
             .with_title(title)
             .with_inner_size(winit::dpi::LogicalSize::new(width, height));
         let cloned_options = options.clone();
-        window_builder = apply_window_options(
-            &window_builder,
-            &options.unwrap_or(WindowOptions::default()),
-        );
+        window_builder = apply_window_options(&window_builder, &options.unwrap_or_default());
 
         let window = window_builder
             .build(&event_loop)

--- a/cgraph/src/app/window.rs
+++ b/cgraph/src/app/window.rs
@@ -86,6 +86,90 @@ struct EventDelegate {
 type RenderFunction = dyn Fn(&mut winit::window::Window, &mut crate::macos::metal::MetalRenderer, &mut SharedObjects)
     + 'static;
 
+pub struct WindowOptions {
+    decorations: bool,
+    resizable: bool,
+    transparent: bool,
+    fullscreen: bool,
+    no_titlebar: bool,
+}
+
+impl Clone for WindowOptions {
+    fn clone(&self) -> Self {
+        WindowOptions {
+            decorations: self.decorations,
+            resizable: self.resizable,
+            transparent: self.transparent,
+            fullscreen: self.fullscreen,
+            no_titlebar: self.no_titlebar,
+        }
+    }
+}
+
+impl Default for WindowOptions {
+    fn default() -> Self {
+        WindowOptions {
+            decorations: true,
+            resizable: true,
+            transparent: false,
+            fullscreen: false,
+            no_titlebar: false,
+        }
+    }
+}
+
+impl WindowOptions {
+    pub fn no_decorations() -> Self {
+        WindowOptions {
+            decorations: false,
+            resizable: true,
+            transparent: false,
+            fullscreen: false,
+            no_titlebar: false,
+        }
+    }
+
+    pub fn resizable() -> Self {
+        WindowOptions {
+            decorations: true,
+            resizable: true,
+            transparent: false,
+            fullscreen: false,
+            no_titlebar: false,
+        }
+    }
+
+    pub fn transparent() -> Self {
+        WindowOptions {
+            decorations: true,
+            resizable: true,
+            transparent: true,
+            fullscreen: false,
+            no_titlebar: false,
+        }
+    }
+
+    pub fn fullscreen() -> Self {
+        WindowOptions {
+            decorations: true,
+            resizable: true,
+            transparent: false,
+            fullscreen: true,
+            no_titlebar: false,
+        }
+    }
+
+    pub fn no_titlebar() -> Self {
+        WindowOptions {
+            decorations: true,
+            resizable: true,
+            transparent: false,
+            fullscreen: false,
+            no_titlebar: true,
+        }
+    }
+}
+
 pub struct Window {
     pub title: String,
     pub width: u32,
@@ -99,14 +183,47 @@ pub struct Window {
     events: Vec<EventDelegate>,
 }
 
+fn apply_window_options(
+    window: &winit::window::WindowBuilder,
+    options: &WindowOptions,
+) -> winit::window::WindowBuilder {
+    let mut builder = window.clone();
+    if !options.decorations {
+        builder = builder.with_decorations(false);
+    }
+    if !options.resizable {
+        builder = builder.with_resizable(false);
+    }
+    if options.transparent {
+        builder = builder.with_transparent(true);
+    }
+
+    if options.fullscreen {
+        // Fullscreen logic can be added here
+    }
+    builder
+}
+
 impl Window {
-    pub fn new(title: &str, width: u32, height: u32) -> Self {
+    pub fn new(title: &str, width: u32, height: u32, options: Option<WindowOptions>) -> Self {
         let event_loop = EventLoop::new();
-        let window = WindowBuilder::new()
+        let mut window_builder = WindowBuilder::new()
             .with_title(title)
-            .with_inner_size(winit::dpi::LogicalSize::new(width, height))
+            .with_inner_size(winit::dpi::LogicalSize::new(width, height));
+        let cloned_options = options.clone();
+        window_builder = apply_window_options(
+            &window_builder,
+            &options.unwrap_or(WindowOptions::default()),
+        );
+
+        let window = window_builder
             .build(&event_loop)
             .expect("Cannot create window");
+
+        if cloned_options.is_some() && cloned_options.unwrap().no_titlebar {
+            #[cfg(target_os = "macos")]
+            crate::macos::win_custom::customize_window(&window);
+        }
         Window {
             title: title.to_string(),
             width,

--- a/cgraph/src/macos.rs
+++ b/cgraph/src/macos.rs
@@ -4,3 +4,4 @@ pub mod shader_code;
 pub mod shaders;
 pub mod shadows;
 pub mod view;
+pub mod win_custom;

--- a/cgraph/src/macos/win_custom.rs
+++ b/cgraph/src/macos/win_custom.rs
@@ -1,0 +1,2 @@
+#[cfg(target_os = "macos")]
+pub fn customize_window(window: &winit::window::Window) {}

--- a/cgraph/src/macos/win_custom.rs
+++ b/cgraph/src/macos/win_custom.rs
@@ -1,2 +1,27 @@
+#![allow(unexpected_cfgs)]
+
 #[cfg(target_os = "macos")]
-pub fn customize_window(window: &winit::window::Window) {}
+pub fn customize_window(window: &winit::window::Window) {
+    use cocoa::appkit::{NSWindowStyleMask, NSWindowTitleVisibility};
+    use cocoa::base::id;
+    use objc::{msg_send, *};
+    use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+
+    unsafe {
+        let ns_window: id = match window.raw_window_handle() {
+            RawWindowHandle::AppKit(handle) => handle.ns_window as id,
+            _ => return,
+        };
+
+        let () =
+            msg_send![ns_window, setTitleVisibility: NSWindowTitleVisibility::NSWindowTitleHidden];
+
+        let () = msg_send![ns_window, setTitlebarAppearsTransparent: true];
+
+        let () = msg_send![ns_window, setStyleMask: NSWindowStyleMask::NSTitledWindowMask
+                                              | NSWindowStyleMask::NSClosableWindowMask
+                                              | NSWindowStyleMask::NSMiniaturizableWindowMask
+                                              | NSWindowStyleMask::NSResizableWindowMask
+                                              | NSWindowStyleMask::NSFullSizeContentViewWindowMask];
+    }
+}


### PR DESCRIPTION
Added basic and advanced window customizations to create a versatile window layout. Added options for:
* `decorations`: (Title bar, etc...)
* `resizable`: (Whether the window is resizable or not)
* `transparent`: (Whether the window is transparent or not)
* `fullscreen`: (If the window is fullscreen by default)
* `no_titlebar`: (Get the behaviour in macOS of getting the close buttons, but no titlebar)

All of this is packed into a struct *`WindowOptions`* that is passed on creation of the window