### PR TITLE
Rendering fonts with CG Graphics

### DIFF
--- a/cgraph/examples/text.rs
+++ b/cgraph/examples/text.rs
@@ -1,0 +1,25 @@
+use cgraph::{
+    self,
+    app::Window,
+    object::primitives::Color,
+    text::{get_font, make_text},
+};
+use glam::Vec2;
+
+fn main() {
+    let mut win = Window::new("Window", 800, 600, None);
+
+    let font = get_font(&win, "BIZ UDMincho", 18.0).unwrap();
+    let object = make_text(
+        font,
+        "おはよう!",
+        Color::new(0.0, 1.0, 0.0, 1.0),
+        3.0,
+        Vec2::new(100.0, 100.0),
+    )
+    .unwrap();
+
+    win.add_object(object);
+
+    win.launch();
+}

--- a/cgraph/src/cgraph.rs
+++ b/cgraph/src/cgraph.rs
@@ -1,5 +1,6 @@
 pub mod app;
 pub mod object;
+pub mod text;
 
 pub mod renderer;
 mod utils;

--- a/cgraph/src/text.rs
+++ b/cgraph/src/text.rs
@@ -1,0 +1,66 @@
+use std::error::Error;
+
+use cfont::font::shape::{TextTransform, produce_text};
+use glam::Vec2;
+
+use crate::{
+    app::Window,
+    object::{Object, Vertex, primitives::Color},
+};
+
+pub struct Font {
+    pub core_font: cfont::font::load::Font,
+    pub transform: cfont::font::shape::TextTransform,
+}
+
+pub fn get_font(window: &Window, name: &str, size: f32) -> Result<Font, Box<dyn Error>> {
+    let font = cfont::font::load::get_system_font(name)?;
+    let transform = TextTransform {
+        font_size: size,
+        position: [0.0, 0.0],
+        canvas_size: [window.width as f32, window.height as f32],
+    };
+    Ok(Font {
+        core_font: font,
+        transform,
+    })
+}
+
+pub fn make_text(
+    font: Font,
+    text: &str,
+    color: Color,
+    z_index: f32,
+    position: Vec2,
+) -> Result<Object, Box<dyn Error>> {
+    let mut result = produce_text(font.core_font, text)?;
+
+    let font_units_per_em = 1000.0;
+    let mut transform = font.transform.clone();
+    transform.position = [position.x, position.y];
+    result.transform_to_canvas(font.transform, font_units_per_em);
+
+    let mut indices: Vec<u32> = vec![];
+    for index in result.indices {
+        indices.push(index as u32);
+    }
+
+    let mut vertices: Vec<Vertex> = vec![];
+    for vertex in result.vertices {
+        let vertex = Vertex {
+            position: Vec2::new(vertex.position[0], -vertex.position[1]),
+            color,
+            z_index,
+            uv: Vec2::new(0.0, 0.0),
+        };
+        vertices.push(vertex)
+    }
+
+    let mut object = Object::new(vertices, indices);
+    object.position = position;
+    object.scale = Vec2::new(1.0, 1.0);
+    object.original_pixel_size = position;
+    object.rotation = 0.0;
+    object.corner_radius = 0.0;
+    Ok(object)
+}


### PR DESCRIPTION
Rendering fonts with Core Graphics is easier. Now, with Core Fonts, font rendering is simple and easy. It supports unicode and ligatures perfectly.

These are the new things available:
* `get_font`: To create a font
* `make_text`: To create the text object
